### PR TITLE
Test-suite audit: coverage, readability & maintainability fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig codifies the repo's existing whitespace conventions so editors
+# apply them automatically and formatting stays consistent across contributors.
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# Example scenario files and all JSON use 4-space indent (already uniform).
+[*.json]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 4
+
+# Markdown uses trailing whitespace for hard line breaks.
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     lint:
         name: Lint
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@v7
 
@@ -44,6 +45,7 @@ jobs:
     test:
         name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
         runs-on: ${{ matrix.os }}
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix:
@@ -97,6 +99,7 @@ jobs:
     test-lowest:
         name: Test (lowest dependency floors)
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
             - uses: actions/checkout@v7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,13 @@ jobs:
     test:
         name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
         runs-on: ${{ matrix.os }}
-        timeout-minutes: 15
+        # Generous enough for the Windows leg, which legitimately runs ~20 min:
+        # pytester spawns a subprocess (and its own HTTP server) per integration
+        # test, and that is far slower on Windows than on Linux (~3 min there).
+        # This is a hang guard, not a performance budget — it only needs to beat
+        # GitHub's 360-minute default, so leave real headroom above the observed
+        # runtime rather than trimming it close.
+        timeout-minutes: 40
         strategy:
             fail-fast: false
             matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,13 @@ uv run pytest-httpchain validate tests/integration/examples/save/test_save_jmesp
 # Deep validation (opt-in): import user functions + check signatures + referenced files
 uv run pytest-httpchain validate --deep --syspath tests/integration/examples tests/integration/examples/save/test_save_user_function.http.json
 
-# Run unit tests with coverage report
-uv run pytest tests/unit --cov=src --cov-report=term-missing
+# Run tests with coverage report.
+# Use `coverage run -m pytest` (NOT `pytest --cov`): the plugin is imported via its
+# pytest11 entry point before pytest-cov starts recording, so `--cov` counts every
+# module-level line (model fields, class bodies) as missed and reports a ~20-point-low
+# floor (e.g. models/entities.py at 40% instead of its real 97%). CI uses this form.
+uv run coverage run -m pytest tests/unit
+uv run coverage report --show-missing
 ```
 
 ## Architecture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,9 @@ pythonpath = [
     ".",
 ]
 testpaths = ["tests"]
+markers = [
+    "slow: subprocess-spawning or sleep-bound integration test; deselect with -m 'not slow'",
+]
 
 [tool.coverage.run]
 source = ["src"]
@@ -137,6 +140,11 @@ branch = true
 precision = 2
 show_missing = true
 skip_covered = false
+# Regression floor for the CI `coverage report` step (full suite under
+# `coverage run -m pytest`, ~92%). Kept a few points below the real number to
+# tolerate platform/Python-version branch differences; ratchet upward as
+# coverage improves rather than letting it silently erode.
+fail_under = 88
 
 [tool.importlinter]
 root_package = "pytest_httpchain"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,10 @@ missing-argument = "ignore"
 
 [tool.pytest]
 minversion = "9.0"
-log_cli = true
+# Logs are captured and shown only for failing tests (pytest's default). Streaming
+# live INFO for every passing test buried real output ~10-27x; opt back in per-run
+# with `-o log_cli=true --log-cli-level=INFO` when debugging.
+log_cli = false
 log_cli_level = "INFO"
 norecursedirs = ["examples"]
 pytester_example_dir = "tests/integration/examples"
@@ -130,6 +133,14 @@ pythonpath = [
 testpaths = ["tests"]
 markers = [
     "slow: subprocess-spawning or sleep-bound integration test; deselect with -m 'not slow'",
+]
+# Treat warnings as errors so dependency deprecations (e.g. across the 3.13/3.14
+# and lowest-floor matrix) fail loudly instead of rotting. The plugin's own
+# ScenarioValidationWarning is intentional behavior that many tests assert on,
+# so it stays a warning; individual tests still escalate it via -W when needed.
+filterwarnings = [
+    "error",
+    "default::pytest_httpchain.ScenarioValidationWarning",
 ]
 
 [tool.coverage.run]

--- a/src/pytest_httpchain/scoping.py
+++ b/src/pytest_httpchain/scoping.py
@@ -190,16 +190,6 @@ def foreach_parameter_names(parallel: ParallelConfig | None) -> set[str]:
             return set()
 
 
-def stage_defined_names(stage: Stage) -> set[str]:
-    """Names available *within a single stage*: its substitutions, parametrize /
-    foreach parameters, and its declared fixtures."""
-    names = substitution_names(stage.substitutions)
-    names |= parameter_names(stage.parametrize)
-    names |= foreach_parameter_names(stage.parallel)
-    names |= set(stage.fixtures)
-    return names
-
-
 def extract_defined_variables(scenario: Scenario) -> set[str]:
     """Extract variable names made available before/within templates (scenario-wide).
 

--- a/tests/integration/examples/conftest.py
+++ b/tests/integration/examples/conftest.py
@@ -56,6 +56,17 @@ def delay(seconds: int):
     return {"delayed": seconds}, HTTPStatus.OK
 
 
+@app.get("/delay_ms/<int:ms>")
+def delay_ms(ms: int):
+    # Millisecond-granularity delay. The mock server is single-threaded, so a
+    # handler keeps sleeping even after the client has timed out, and teardown
+    # blocks until it returns. Timeout tests should use this (e.g. /delay_ms/600
+    # with a 0.1s client timeout) instead of whole-second /delay to keep the
+    # timeout margin without paying seconds of teardown sleep on every run.
+    time.sleep(ms / 1000)
+    return {"delayed_ms": ms}, HTTPStatus.OK
+
+
 # ============ Echo Endpoints (for body type tests) ============
 
 

--- a/tests/integration/examples/errors/test_timeout_error.http.json
+++ b/tests/integration/examples/errors/test_timeout_error.http.json
@@ -5,8 +5,8 @@
             "description": "Request should timeout",
             "fixtures": ["server"],
             "request": {
-                "url": "{{ server }}/delay/5",
-                "timeout": 0.5
+                "url": "{{ server }}/delay_ms/600",
+                "timeout": 0.1
             },
             "response": [
                 {

--- a/tests/integration/examples/verify.py
+++ b/tests/integration/examples/verify.py
@@ -16,3 +16,18 @@ def verify_json_field(response: httpx.Response, field: str, expected: str) -> bo
     """Verify a specific JSON field has expected value."""
     data = response.json()
     return data.get(field) == expected
+
+
+def verify_returns_false(response: httpx.Response) -> bool:
+    """A verify function that fails by returning False."""
+    return False
+
+
+def verify_returns_non_bool(response: httpx.Response):
+    """A verify function that returns a non-bool, which must be rejected."""
+    return "not a bool"
+
+
+def verify_raises(response: httpx.Response) -> bool:
+    """A verify function that raises; must surface as a clean verification failure."""
+    raise ValueError("boom in verify function")

--- a/tests/integration/examples/verify/test_verify_user_function_false.http.json
+++ b/tests/integration/examples/verify/test_verify_user_function_false.http.json
@@ -1,0 +1,20 @@
+{
+    "stages": [
+        {
+            "name": "verify_function_returns_false",
+            "description": "A verify function returning False fails the stage",
+            "fixtures": ["server"],
+            "request": {
+                "url": "{{ server }}/ok"
+            },
+            "response": [
+                {
+                    "verify": {
+                        "status": 200,
+                        "user_functions": ["verify:verify_returns_false"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/integration/examples/verify/test_verify_user_function_non_bool.http.json
+++ b/tests/integration/examples/verify/test_verify_user_function_non_bool.http.json
@@ -1,0 +1,20 @@
+{
+    "stages": [
+        {
+            "name": "verify_function_returns_non_bool",
+            "description": "A verify function returning a non-bool is rejected",
+            "fixtures": ["server"],
+            "request": {
+                "url": "{{ server }}/ok"
+            },
+            "response": [
+                {
+                    "verify": {
+                        "status": 200,
+                        "user_functions": ["verify:verify_returns_non_bool"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/integration/examples/verify/test_verify_user_function_raises.http.json
+++ b/tests/integration/examples/verify/test_verify_user_function_raises.http.json
@@ -1,0 +1,20 @@
+{
+    "stages": [
+        {
+            "name": "verify_function_raises",
+            "description": "A raising verify function surfaces as a clean verification failure",
+            "fixtures": ["server"],
+            "request": {
+                "url": "{{ server }}/ok"
+            },
+            "response": [
+                {
+                    "verify": {
+                        "status": 200,
+                        "user_functions": ["verify:verify_raises"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -1,3 +1,8 @@
+import socket
+import sys
+
+import pytest
+
 from tests.integration.conftest import run_scenario
 
 
@@ -52,13 +57,32 @@ def test_connection_refused(pytester):
     # "actively refused" — but GitHub's Windows CI runners silently DROP
     # loopback SYNs to closed ports (verified even for a just-released bound
     # port), so the failure there surfaces as the request timeout instead.
+    # "timed out" is accepted only on Windows: on POSIX a timeout instead of a
+    # refusal is a real regression and must not be masked.
     out = result.stdout.str()
-    accepted = ("Connection refused", "actively refused", "timed out")
+    accepted = ("Connection refused", "actively refused")
+    if sys.platform == "win32":
+        accepted += ("timed out",)
     assert any(text in out for text in accepted), out
+
+
+_UNRESOLVABLE_HOST = "this-hostname-definitely-does-not-exist-12345.invalid"
 
 
 def test_invalid_hostname(pytester):
     """Test error handling for invalid hostname (DNS resolution failure)"""
+    # This is the suite's only real-network dependency. Some resolvers (captive
+    # portals, ISPs, corporate DNS) wildcard NXDOMAIN and hand back an address
+    # for any name, which turns the intended resolution failure into a
+    # connection/timeout error and flakes the assertion below. Skip rather than
+    # flake when the environment's resolver hijacks the lookup.
+    try:
+        socket.getaddrinfo(_UNRESOLVABLE_HOST, 80)
+    except socket.gaierror:
+        pass  # good: the resolver correctly fails to resolve the bogus name
+    else:
+        pytest.skip("resolver wildcards NXDOMAIN; cannot test DNS failure here")
+
     result = run_scenario(pytester, "errors/test_invalid_hostname.http.json")
     result.assert_outcomes(errors=0, failed=1, passed=0)
     # Must fail specifically because the host name could not be resolved (DNS),

--- a/tests/integration/test_ordering.py
+++ b/tests/integration/test_ordering.py
@@ -17,6 +17,11 @@ incrementing, so any interleaving, reordering, or context reset fails
 immediately.
 """
 
+import pytest
+
+# Every test here spawns pytester subprocesses (runpytest_subprocess).
+pytestmark = pytest.mark.slow
+
 CHAIN_SCENARIOS = [
     "xdist/test_chain_a.http.json",
     "xdist/test_chain_b.http.json",

--- a/tests/integration/test_parallel.py
+++ b/tests/integration/test_parallel.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.integration.conftest import run_scenario
 
 
@@ -54,6 +56,7 @@ def test_parallel_no_partial_save(pytester):
     result.assert_outcomes(errors=0, failed=1, passed=1)
 
 
+@pytest.mark.slow
 def test_rate_limiter_threads_not_leaked(pytester):
     """Each rate-limited stage execution used to construct a pyrate-limiter
     Limiter and never dispose it — and each Limiter owns a leaker daemon thread

--- a/tests/integration/test_primer.py
+++ b/tests/integration/test_primer.py
@@ -3,8 +3,6 @@ from tests.integration.conftest import run_scenario
 
 def test_primer(pytester):
     result = run_scenario(pytester, "primer/test_primer.http.json", "primer/common.json")
-    print(result.stdout.str())
-    print(result.stderr.str())
     result.assert_outcomes(
         errors=0,
         failed=0,

--- a/tests/integration/test_verify.py
+++ b/tests/integration/test_verify.py
@@ -26,6 +26,27 @@ def test_verify_user_function(pytester):
     result.assert_outcomes(errors=0, failed=0, passed=1)
 
 
+def test_verify_user_function_returns_false(pytester):
+    """A verify function returning False fails the stage with a clear message."""
+    result = run_scenario(pytester, "verify/test_verify_user_function_false.http.json", "verify.py")
+    result.assert_outcomes(errors=0, failed=1, passed=0)
+    result.stdout.fnmatch_lines(["*verification failed*"])
+
+
+def test_verify_user_function_returns_non_bool(pytester):
+    """A verify function returning a non-bool is rejected, not coerced."""
+    result = run_scenario(pytester, "verify/test_verify_user_function_non_bool.http.json", "verify.py")
+    result.assert_outcomes(errors=0, failed=1, passed=0)
+    result.stdout.fnmatch_lines(["*must return bool*"])
+
+
+def test_verify_user_function_raises(pytester):
+    """A raising verify function surfaces as a clean stage failure, not a raw traceback."""
+    result = run_scenario(pytester, "verify/test_verify_user_function_raises.http.json", "verify.py")
+    result.assert_outcomes(errors=0, failed=1, passed=0)
+    result.stdout.fnmatch_lines(["*Error calling user function*"])
+
+
 def test_verify_body_schema(pytester):
     """Test JSON schema validation"""
     result = run_scenario(pytester, "verify/test_verify_body_schema.http.json", "verify/schema.json")

--- a/tests/integration/test_xdist.py
+++ b/tests/integration/test_xdist.py
@@ -13,6 +13,10 @@ values), so a split across workers cannot pass by accident.
 
 import pytest
 
+# Every test here spawns pytester subprocesses (runpytest_subprocess) with their
+# own per-stage HTTP servers — the slowest family in the suite.
+pytestmark = pytest.mark.slow
+
 SCENARIO = "save/test_save_jmespath.http.json"
 
 

--- a/tests/unit/models/conftest.py
+++ b/tests/unit/models/conftest.py
@@ -12,7 +12,25 @@ boilerplate. Import them directly, mirroring how the integration suite imports
 
 from typing import Any
 
+import pytest
+from pydantic import ValidationError
+
 from pytest_httpchain.models import Request, Stage
+
+
+def assert_error_types(exc_info: pytest.ExceptionInfo[ValidationError], *expected_types: str) -> None:
+    """Assert the raised ValidationError carries each given pydantic error ``type``.
+
+    Pydantic's built-in error *codes* (``extra_forbidden``, ``union_tag_invalid``,
+    ``too_short``, ``too_long``, ...) are stable across versions, whereas the
+    human-readable messages ("Extra inputs are not permitted", ...) are not — so
+    tests for built-in validation failures should assert on the code, not the
+    prose. (Failures from the models' own validators keep matching their own
+    message text, which this project owns and controls.)
+    """
+    actual = [err["type"] for err in exc_info.value.errors()]
+    for expected in expected_types:
+        assert expected in actual, f"expected pydantic error type {expected!r}, got {actual}"
 
 
 def make_request(url: str = "https://example.com", **overrides: Any) -> Request:

--- a/tests/unit/models/conftest.py
+++ b/tests/unit/models/conftest.py
@@ -1,0 +1,36 @@
+"""Shared factories for the model unit tests.
+
+Most of these tests only need a *valid, incidental* Stage or Request as
+scaffolding while they exercise one specific field. These helpers provide that
+minimal object so a call site can pass just the field under test instead of
+re-spelling the whole ``Stage(name=..., request=Request(url=...), ...)``
+boilerplate. Import them directly, mirroring how the integration suite imports
+``run_scenario`` from its conftest::
+
+    from tests.unit.models.conftest import make_stage, make_request
+"""
+
+from typing import Any
+
+from pytest_httpchain.models import Request, Stage
+
+
+def make_request(url: str = "https://example.com", **overrides: Any) -> Request:
+    """A minimal valid Request; override any field via keyword."""
+    return Request(url=url, **overrides)
+
+
+def make_stage(name: str = "test", request: Request | None = None, **overrides: Any) -> Stage:
+    """A minimal valid Stage with an incidental request; override any field.
+
+    Pass ``request=make_request(...)`` when the request itself is what matters.
+    """
+    return Stage(name=name, request=request if request is not None else make_request(), **overrides)
+
+
+def stage_dict(**overrides: Any) -> dict[str, Any]:
+    """Raw-dict form of a minimal Stage for ``Stage.model_validate(...)`` tests.
+
+    Override or inject (including deliberately invalid) keys via keyword.
+    """
+    return {"name": "test", "request": {"url": "https://example.com"}, **overrides}

--- a/tests/unit/models/test_body_types.py
+++ b/tests/unit/models/test_body_types.py
@@ -18,6 +18,7 @@ from pytest_httpchain.models.entities import (
     TextBody,
     XmlBody,
 )
+from tests.unit.models.conftest import assert_error_types
 
 
 class TestTextBody:
@@ -395,5 +396,6 @@ class TestBodyTypeDiscriminatorExtended:
 )
 def test_body_extra_fields_forbidden(construct):
     """Every body model rejects unknown keys (extra='forbid')."""
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+    with pytest.raises(ValidationError) as exc_info:
         construct()
+    assert_error_types(exc_info, "extra_forbidden")

--- a/tests/unit/models/test_entities.py
+++ b/tests/unit/models/test_entities.py
@@ -1,0 +1,67 @@
+"""Unit tests for module-level helpers in models/entities.py.
+
+Model classes themselves are covered by the sibling test modules
+(test_parameters.py, test_request.py, test_stage_scenario.py, ...); this file
+covers the free functions that live alongside them.
+"""
+
+import pytest
+
+from pytest_httpchain.models.entities import (
+    CombinationsParameter,
+    IndividualParameter,
+    parametrize_values_contain_template,
+)
+
+
+class TestParametrizeValuesContainTemplate:
+    """Truth table for parametrize_values_contain_template().
+
+    Contract (per its docstring): return True iff any parametrize VALUE holds a
+    ``{{ }}`` template; ``ids`` are never inspected. Both parameter shapes
+    (individual and combinations) must be walked — the combinations branch has
+    no other test exercising it.
+    """
+
+    @pytest.mark.parametrize(
+        "parametrize, expected",
+        [
+            pytest.param(None, False, id="none"),
+            pytest.param([], False, id="empty-list"),
+            pytest.param(
+                [IndividualParameter(individual={"x": [1, 2]})],
+                False,
+                id="individual-no-template",
+            ),
+            pytest.param(
+                [IndividualParameter(individual={"x": ["{{ a }}", 2]})],
+                True,
+                id="individual-template-in-value",
+            ),
+            pytest.param(
+                [IndividualParameter(individual={"x": [1, 2]}, ids=["{{ a }}", "b"])],
+                False,
+                id="individual-template-in-ids-only",
+            ),
+            pytest.param(
+                [CombinationsParameter(combinations=[{"x": 1, "y": 2}])],
+                False,
+                id="combinations-no-template",
+            ),
+            pytest.param(
+                [CombinationsParameter(combinations=[{"x": "{{ a }}", "y": 2}])],
+                True,
+                id="combinations-template-in-value",
+            ),
+            pytest.param(
+                [
+                    IndividualParameter(individual={"x": [1]}),
+                    CombinationsParameter(combinations=[{"y": "{{ b }}"}]),
+                ],
+                True,
+                id="mixed-template-in-second",
+            ),
+        ],
+    )
+    def test_truth_table(self, parametrize, expected):
+        assert parametrize_values_contain_template(parametrize) is expected

--- a/tests/unit/models/test_extra_forbidden.py
+++ b/tests/unit/models/test_extra_forbidden.py
@@ -53,8 +53,10 @@ def test_parallel_config_extra_key_rejected():
         "request": {"url": "https://x.test/"},
         "parallel": {"repeat": 2, "max_concurency": 5},
     }
-    with pytest.raises(ValidationError, match="max_concurency"):
+    with pytest.raises(ValidationError) as exc_info:
         Stage.model_validate(stage)
+    errors = exc_info.value.errors()
+    assert any(e["type"] == "extra_forbidden" and "max_concurency" in e["loc"] for e in errors)
 
 
 def test_schema_key_dropped_at_every_model_position():

--- a/tests/unit/models/test_parallel_config.py
+++ b/tests/unit/models/test_parallel_config.py
@@ -11,6 +11,7 @@ from pytest_httpchain.models.entities import (
     Request,
     Stage,
 )
+from tests.unit.models.conftest import make_request, make_stage
 
 
 class TestParallelConfigBase:
@@ -137,9 +138,8 @@ class TestParallelConfigDiscriminator:
 
     def test_discriminator_repeat(self):
         """Test discriminator identifies ParallelRepeatConfig."""
-        stage = Stage(
+        stage = make_stage(
             name="load-test",
-            request=Request(url="https://example.com"),
             parallel=ParallelRepeatConfig(repeat=100),
         )
         assert isinstance(stage.parallel, ParallelRepeatConfig)
@@ -147,9 +147,8 @@ class TestParallelConfigDiscriminator:
 
     def test_discriminator_foreach(self):
         """Test discriminator identifies ParallelForeachConfig."""
-        stage = Stage(
+        stage = make_stage(
             name="batch-test",
-            request=Request(url="https://example.com"),
             parallel=ParallelForeachConfig(foreach=[IndividualParameter(individual={"id": [1, 2, 3]})]),
         )
         assert isinstance(stage.parallel, ParallelForeachConfig)
@@ -157,11 +156,7 @@ class TestParallelConfigDiscriminator:
     def test_discriminator_invalid_rejected(self):
         """Test that invalid parallel config type is rejected."""
         with pytest.raises(ValidationError, match="does not match any of the expected tags"):
-            Stage(
-                name="test",
-                request=Request(url="https://example.com"),
-                parallel={"invalid": "value"},
-            )
+            make_stage(parallel={"invalid": "value"})
 
 
 class TestParallelInStage:
@@ -174,9 +169,9 @@ class TestParallelInStage:
 
     def test_stage_repeat_with_full_config(self):
         """Test Stage with full repeat configuration."""
-        stage = Stage(
+        stage = make_stage(
             name="stress-test",
-            request=Request(url="https://example.com/api"),
+            request=make_request(url="https://example.com/api"),
             parallel=ParallelRepeatConfig(
                 repeat=1000,
                 max_concurrency=50,
@@ -190,9 +185,9 @@ class TestParallelInStage:
 
     def test_stage_foreach_with_template_params(self):
         """Test Stage with foreach using template parameters."""
-        stage = Stage(
+        stage = make_stage(
             name="batch-test",
-            request=Request(url="https://example.com/{{ item_id }}"),
+            request=make_request(url="https://example.com/{{ item_id }}"),
             parallel=ParallelForeachConfig(
                 foreach=[IndividualParameter(individual={"item_id": "{{ item_ids }}"})],
                 max_concurrency=10,

--- a/tests/unit/models/test_parallel_config.py
+++ b/tests/unit/models/test_parallel_config.py
@@ -11,7 +11,7 @@ from pytest_httpchain.models.entities import (
     Request,
     Stage,
 )
-from tests.unit.models.conftest import make_request, make_stage
+from tests.unit.models.conftest import assert_error_types, make_request, make_stage
 
 
 class TestParallelConfigBase:
@@ -76,8 +76,9 @@ class TestParallelRepeatConfig:
 
     def test_repeat_extra_fields_forbidden(self):
         """Test that extra fields are not allowed."""
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        with pytest.raises(ValidationError) as exc_info:
             ParallelRepeatConfig(repeat=10, extra="field")
+        assert_error_types(exc_info, "extra_forbidden")
 
 
 class TestParallelForeachConfig:
@@ -120,11 +121,12 @@ class TestParallelForeachConfig:
 
     def test_foreach_extra_fields_forbidden(self):
         """Test that extra fields are not allowed."""
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        with pytest.raises(ValidationError) as exc_info:
             ParallelForeachConfig(
                 foreach=[IndividualParameter(individual={"x": [1]})],
                 extra="field",
             )
+        assert_error_types(exc_info, "extra_forbidden")
 
     def test_empty_foreach_rejected(self):
         """An empty foreach is meaningless: at runtime it would silently run the
@@ -155,8 +157,9 @@ class TestParallelConfigDiscriminator:
 
     def test_discriminator_invalid_rejected(self):
         """Test that invalid parallel config type is rejected."""
-        with pytest.raises(ValidationError, match="does not match any of the expected tags"):
+        with pytest.raises(ValidationError) as exc_info:
             make_stage(parallel={"invalid": "value"})
+        assert_error_types(exc_info, "union_tag_invalid")
 
 
 class TestParallelInStage:

--- a/tests/unit/models/test_parameters.py
+++ b/tests/unit/models/test_parameters.py
@@ -9,7 +9,7 @@ from pytest_httpchain.models.entities import (
     Request,
     Stage,
 )
-from tests.unit.models.conftest import make_request, make_stage
+from tests.unit.models.conftest import assert_error_types, make_request, make_stage
 
 
 class TestIndividualParameter:
@@ -43,8 +43,9 @@ class TestIndividualParameter:
 
     def test_individual_empty_values_rejected(self):
         """Test that empty values list is rejected."""
-        with pytest.raises(ValidationError, match="at least 1"):
+        with pytest.raises(ValidationError) as exc_info:
             IndividualParameter(individual={"x": []})
+        assert_error_types(exc_info, "too_short")
 
     def test_individual_with_template_expression(self):
         """Test IndividualParameter with template expression."""
@@ -62,8 +63,9 @@ class TestIndividualParameter:
 
     def test_individual_multi_key_rejected(self):
         """M22: more than one parameter per step is rejected, not silently truncated."""
-        with pytest.raises(ValidationError, match="at most 1"):
+        with pytest.raises(ValidationError) as exc_info:
             IndividualParameter(individual={"x": [1, 2], "y": [3, 4]})
+        assert_error_types(exc_info, "too_long")
 
 
 class TestCombinationsParameter:
@@ -119,8 +121,9 @@ class TestCombinationsParameter:
 
     def test_combinations_empty_dict_rejected(self):
         """Test that empty combination dict is rejected."""
-        with pytest.raises(ValidationError, match="at least 1"):
+        with pytest.raises(ValidationError) as exc_info:
             CombinationsParameter(combinations=[{}])
+        assert_error_types(exc_info, "too_short")
 
     def test_combinations_empty_list_rejected(self):
         """An empty combinations list expands to zero iterations at runtime
@@ -175,8 +178,9 @@ class TestParameterDiscriminator:
 
     def test_discriminator_invalid_type_rejected(self):
         """Test that invalid parameter type is rejected."""
-        with pytest.raises(ValidationError, match="does not match any of the expected tags"):
+        with pytest.raises(ValidationError) as exc_info:
             make_stage(parametrize=[{"invalid": "value"}])
+        assert_error_types(exc_info, "union_tag_invalid")
 
 
 class TestParametersInStage:

--- a/tests/unit/models/test_parameters.py
+++ b/tests/unit/models/test_parameters.py
@@ -9,6 +9,7 @@ from pytest_httpchain.models.entities import (
     Request,
     Stage,
 )
+from tests.unit.models.conftest import make_request, make_stage
 
 
 class TestIndividualParameter:
@@ -148,31 +149,21 @@ class TestParameterDiscriminator:
 
     def test_discriminator_individual(self):
         """Test discriminator identifies IndividualParameter."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            parametrize=[IndividualParameter(individual={"x": [1, 2, 3]})],
-        )
+        stage = make_stage(parametrize=[IndividualParameter(individual={"x": [1, 2, 3]})])
         assert stage.parametrize is not None
         assert len(stage.parametrize) == 1
         assert isinstance(stage.parametrize[0], IndividualParameter)
 
     def test_discriminator_combinations(self):
         """Test discriminator identifies CombinationsParameter."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            parametrize=[CombinationsParameter(combinations=[{"x": 1}, {"x": 2}])],
-        )
+        stage = make_stage(parametrize=[CombinationsParameter(combinations=[{"x": 1}, {"x": 2}])])
         assert stage.parametrize is not None
         assert len(stage.parametrize) == 1
         assert isinstance(stage.parametrize[0], CombinationsParameter)
 
     def test_discriminator_mixed_parameters(self):
         """Test discriminator with mixed parameter types."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
+        stage = make_stage(
             parametrize=[
                 IndividualParameter(individual={"id": [1, 2]}),
                 CombinationsParameter(combinations=[{"a": 1, "b": 2}, {"a": 3, "b": 4}]),
@@ -185,11 +176,7 @@ class TestParameterDiscriminator:
     def test_discriminator_invalid_type_rejected(self):
         """Test that invalid parameter type is rejected."""
         with pytest.raises(ValidationError, match="does not match any of the expected tags"):
-            Stage(
-                name="test",
-                request=Request(url="https://example.com"),
-                parametrize=[{"invalid": "value"}],
-            )
+            make_stage(parametrize=[{"invalid": "value"}])
 
 
 class TestParametersInStage:
@@ -202,18 +189,13 @@ class TestParametersInStage:
 
     def test_stage_with_empty_parametrize(self):
         """Test Stage with empty parametrize list."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            parametrize=[],
-        )
+        stage = make_stage(parametrize=[])
         assert stage.parametrize == []
 
     def test_stage_parametrize_with_template_url(self):
         """Test Stage with parametrize and template URL."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com/users/{{ user_id }}"),
+        stage = make_stage(
+            request=make_request(url="https://example.com/users/{{ user_id }}"),
             parametrize=[IndividualParameter(individual={"user_id": [1, 2, 3]})],
         )
         assert stage.parametrize is not None

--- a/tests/unit/models/test_save_types.py
+++ b/tests/unit/models/test_save_types.py
@@ -6,15 +6,14 @@ from pydantic import ValidationError
 from pytest_httpchain.models.entities import (
     FunctionsSubstitution,
     JMESPathSave,
-    Request,
     SaveStep,
-    Stage,
     SubstitutionsSave,
     UserFunctionKwargs,
     UserFunctionName,
     UserFunctionsSave,
     VarsSubstitution,
 )
+from tests.unit.models.conftest import make_stage
 
 
 class TestJMESPathSave:
@@ -211,20 +210,14 @@ class TestSaveStepInStage:
 
     def test_stage_with_jmespath_save(self):
         """Test Stage with JMESPath save step."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            response=[SaveStep(save=JMESPathSave(jmespath={"token": "data.token"}))],
-        )
+        stage = make_stage(response=[SaveStep(save=JMESPathSave(jmespath={"token": "data.token"}))])
         assert len(stage.response) == 1
         assert isinstance(stage.response[0], SaveStep)
         assert isinstance(stage.response[0].save, JMESPathSave)
 
     def test_stage_with_multiple_save_steps(self):
         """Test Stage with multiple save steps."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
+        stage = make_stage(
             response=[
                 SaveStep(save=JMESPathSave(jmespath={"id": "data.id"})),
                 SaveStep(save=UserFunctionsSave(user_functions=[UserFunctionName("custom:saver")])),

--- a/tests/unit/models/test_save_types.py
+++ b/tests/unit/models/test_save_types.py
@@ -13,7 +13,7 @@ from pytest_httpchain.models.entities import (
     UserFunctionsSave,
     VarsSubstitution,
 )
-from tests.unit.models.conftest import make_stage
+from tests.unit.models.conftest import assert_error_types, make_stage
 
 
 class TestJMESPathSave:
@@ -65,8 +65,9 @@ class TestJMESPathSave:
 
     def test_jmespath_extra_fields_forbidden(self):
         """Test that extra fields are not allowed."""
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        with pytest.raises(ValidationError) as exc_info:
             JMESPathSave(jmespath={"x": "y"}, extra="field")
+        assert_error_types(exc_info, "extra_forbidden")
 
     @pytest.mark.parametrize("bad_key", ["my-var", "with space", "1leading", "class"])
     def test_jmespath_non_identifier_key_rejected(self, bad_key: str):
@@ -120,8 +121,9 @@ class TestSubstitutionsSave:
 
     def test_substitutions_extra_fields_forbidden(self):
         """Test that extra fields are not allowed."""
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        with pytest.raises(ValidationError) as exc_info:
             SubstitutionsSave(substitutions=[], extra="field")
+        assert_error_types(exc_info, "extra_forbidden")
 
 
 class TestUserFunctionsSave:
@@ -177,8 +179,9 @@ class TestUserFunctionsSave:
 
     def test_user_functions_extra_fields_forbidden(self):
         """Test that extra fields are not allowed."""
-        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        with pytest.raises(ValidationError) as exc_info:
             UserFunctionsSave(user_functions=[], extra="field")
+        assert_error_types(exc_info, "extra_forbidden")
 
 
 class TestSaveDiscriminator:
@@ -201,8 +204,9 @@ class TestSaveDiscriminator:
 
     def test_discriminator_invalid_rejected(self):
         """Test that invalid save type is rejected."""
-        with pytest.raises(ValidationError, match="does not match any of the expected tags"):
+        with pytest.raises(ValidationError) as exc_info:
             SaveStep(save={"invalid": "value"})
+        assert_error_types(exc_info, "union_tag_invalid")
 
 
 class TestSaveStepInStage:

--- a/tests/unit/models/test_ssl_config.py
+++ b/tests/unit/models/test_ssl_config.py
@@ -128,10 +128,16 @@ class TestSSLConfigValidation:
     """Tests for SSLConfig validation."""
 
     def test_verify_non_template_string_treated_as_path(self):
-        """Test that non-template strings for verify are treated as paths."""
-        # Non-template string is treated as a path
-        config = SSLConfig(verify=Path("some/path.crt"))
+        """A plain (non-template) string for verify is coerced to a Path."""
+        config = SSLConfig(verify="some/path.crt")
         assert isinstance(config.verify, Path)
+        assert config.verify == Path("some/path.crt")
+
+    def test_verify_template_string_kept_as_string(self):
+        """A template string for verify is left as a str for later substitution."""
+        config = SSLConfig(verify="{{ ca_bundle }}")
+        assert config.verify == "{{ ca_bundle }}"
+        assert isinstance(config.verify, str)
 
     def test_cert_invalid_tuple_length(self):
         """Test that cert tuple must have exactly 2 elements."""

--- a/tests/unit/models/test_stage_scenario.py
+++ b/tests/unit/models/test_stage_scenario.py
@@ -15,6 +15,7 @@ from pytest_httpchain.models.entities import (
     UserFunctionName,
     VarsSubstitution,
 )
+from tests.unit.models.conftest import make_request, make_stage
 
 
 class TestStageName:
@@ -22,20 +23,17 @@ class TestStageName:
 
     def test_stage_name_default_empty(self):
         """Test that stage name defaults to empty string when not provided."""
-        stage = Stage(request=Request(url="https://example.com"))
+        stage = Stage(request=make_request())
         assert stage.name == ""
 
     def test_stage_name_simple(self):
         """Test simple stage name."""
-        stage = Stage(name="get-users", request=Request(url="https://example.com"))
+        stage = make_stage(name="get-users")
         assert stage.name == "get-users"
 
     def test_stage_name_descriptive(self):
         """Test descriptive stage name."""
-        stage = Stage(
-            name="Create new user account",
-            request=Request(url="https://example.com"),
-        )
+        stage = make_stage(name="Create new user account")
         assert stage.name == "Create new user account"
 
 
@@ -44,16 +42,12 @@ class TestStageDescription:
 
     def test_stage_description_default_none(self):
         """Test default description is None."""
-        stage = Stage(name="test", request=Request(url="https://example.com"))
+        stage = make_stage()
         assert stage.description is None
 
     def test_stage_description_custom(self):
         """Test custom description."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            description="This stage tests the user creation endpoint",
-        )
+        stage = make_stage(description="This stage tests the user creation endpoint")
         assert stage.description == "This stage tests the user creation endpoint"
 
 
@@ -62,34 +56,22 @@ class TestStageMarks:
 
     def test_stage_marks_default_empty(self):
         """Test default marks is empty list."""
-        stage = Stage(name="test", request=Request(url="https://example.com"))
+        stage = make_stage()
         assert stage.marks == []
 
     def test_stage_marks_skip(self):
         """Test stage with skip marker."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            marks=["skip"],
-        )
+        stage = make_stage(marks=["skip"])
         assert "skip" in stage.marks
 
     def test_stage_marks_xfail(self):
         """Test stage with xfail marker."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            marks=["xfail"],
-        )
+        stage = make_stage(marks=["xfail"])
         assert "xfail" in stage.marks
 
     def test_stage_marks_multiple(self):
         """Test stage with multiple markers."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            marks=["slow", "integration", "requires_auth"],
-        )
+        stage = make_stage(marks=["slow", "integration", "requires_auth"])
         assert len(stage.marks) == 3
 
 
@@ -98,25 +80,17 @@ class TestStageFixtures:
 
     def test_stage_fixtures_default_empty(self):
         """Test default fixtures is empty list."""
-        stage = Stage(name="test", request=Request(url="https://example.com"))
+        stage = make_stage()
         assert stage.fixtures == []
 
     def test_stage_fixtures_single(self):
         """Test stage with single fixture."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            fixtures=["auth_token"],
-        )
+        stage = make_stage(fixtures=["auth_token"])
         assert "auth_token" in stage.fixtures
 
     def test_stage_fixtures_multiple(self):
         """Test stage with multiple fixtures."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            fixtures=["db_connection", "auth_token", "test_user"],
-        )
+        stage = make_stage(fixtures=["db_connection", "auth_token", "test_user"])
         assert len(stage.fixtures) == 3
 
 
@@ -125,34 +99,22 @@ class TestStageAlwaysRun:
 
     def test_stage_always_run_default_false(self):
         """Test default always_run is False."""
-        stage = Stage(name="test", request=Request(url="https://example.com"))
+        stage = make_stage()
         assert stage.always_run is False
 
     def test_stage_always_run_true(self):
         """Test always_run set to True."""
-        stage = Stage(
-            name="cleanup",
-            request=Request(url="https://example.com/cleanup"),
-            always_run=True,
-        )
+        stage = make_stage(name="cleanup", always_run=True)
         assert stage.always_run is True
 
     def test_stage_always_run_template(self):
         """Test always_run with template expression."""
-        stage = Stage(
-            name="conditional",
-            request=Request(url="https://example.com"),
-            always_run="{{ should_always_run }}",
-        )
+        stage = make_stage(name="conditional", always_run="{{ should_always_run }}")
         assert stage.always_run == "{{ should_always_run }}"
 
     def test_stage_always_run_conditional_template(self):
         """Test always_run with conditional template."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            always_run="{{ env == 'production' }}",
-        )
+        stage = make_stage(always_run="{{ env == 'production' }}")
         assert stage.always_run == "{{ env == 'production' }}"
 
 
@@ -221,7 +183,7 @@ class TestScenarioStages:
 
     def test_scenario_single_stage(self):
         """Test scenario with single stage."""
-        scenario = Scenario(stages=[Stage(name="get-users", request=Request(url="https://example.com/users"))])
+        scenario = Scenario(stages=[make_stage(name="get-users")])
         assert len(scenario.stages) == 1
         assert isinstance(scenario.stages[0], Stage)
 
@@ -229,9 +191,9 @@ class TestScenarioStages:
         """Test scenario with multiple stages."""
         scenario = Scenario(
             stages=[
-                Stage(name="login", request=Request(url="https://example.com/login")),
-                Stage(name="get-profile", request=Request(url="https://example.com/profile")),
-                Stage(name="logout", request=Request(url="https://example.com/logout")),
+                make_stage(name="login"),
+                make_stage(name="get-profile"),
+                make_stage(name="logout"),
             ]
         )
         assert len(scenario.stages) == 3

--- a/tests/unit/models/test_stage_scenario.py
+++ b/tests/unit/models/test_stage_scenario.py
@@ -18,135 +18,70 @@ from pytest_httpchain.models.entities import (
 from tests.unit.models.conftest import make_request, make_stage
 
 
-class TestStageName:
-    """Tests for Stage.name field."""
+class TestStageFields:
+    """Per-field defaults and round-trips for Stage's simple fields."""
 
-    def test_stage_name_default_empty(self):
-        """Test that stage name defaults to empty string when not provided."""
-        stage = Stage(request=make_request())
-        assert stage.name == ""
+    @pytest.mark.parametrize(
+        "attr, default",
+        [
+            ("description", None),
+            ("marks", []),
+            ("fixtures", []),
+            ("always_run", False),
+        ],
+    )
+    def test_field_default(self, attr, default):
+        assert getattr(make_stage(), attr) == default
 
-    def test_stage_name_simple(self):
-        """Test simple stage name."""
-        stage = make_stage(name="get-users")
-        assert stage.name == "get-users"
+    def test_name_defaults_to_empty_string(self):
+        # name is the one field make_stage() fills in, so build the stage directly.
+        assert Stage(request=make_request()).name == ""
 
-    def test_stage_name_descriptive(self):
-        """Test descriptive stage name."""
-        stage = make_stage(name="Create new user account")
-        assert stage.name == "Create new user account"
-
-
-class TestStageDescription:
-    """Tests for Stage.description field."""
-
-    def test_stage_description_default_none(self):
-        """Test default description is None."""
-        stage = make_stage()
-        assert stage.description is None
-
-    def test_stage_description_custom(self):
-        """Test custom description."""
-        stage = make_stage(description="This stage tests the user creation endpoint")
-        assert stage.description == "This stage tests the user creation endpoint"
-
-
-class TestStageMarks:
-    """Tests for Stage.marks field."""
-
-    def test_stage_marks_default_empty(self):
-        """Test default marks is empty list."""
-        stage = make_stage()
-        assert stage.marks == []
-
-    def test_stage_marks_skip(self):
-        """Test stage with skip marker."""
-        stage = make_stage(marks=["skip"])
-        assert "skip" in stage.marks
-
-    def test_stage_marks_xfail(self):
-        """Test stage with xfail marker."""
-        stage = make_stage(marks=["xfail"])
-        assert "xfail" in stage.marks
-
-    def test_stage_marks_multiple(self):
-        """Test stage with multiple markers."""
-        stage = make_stage(marks=["slow", "integration", "requires_auth"])
-        assert len(stage.marks) == 3
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            pytest.param("name", "get-users", id="name-simple"),
+            pytest.param("name", "Create new user account", id="name-descriptive"),
+            pytest.param("description", "This stage tests the user creation endpoint", id="description"),
+            pytest.param("marks", ["skip"], id="marks-single"),
+            pytest.param("marks", ["xfail"], id="marks-xfail"),
+            pytest.param("marks", ["slow", "integration", "requires_auth"], id="marks-multiple"),
+            pytest.param("fixtures", ["auth_token"], id="fixtures-single"),
+            pytest.param("fixtures", ["db_connection", "auth_token", "test_user"], id="fixtures-multiple"),
+            pytest.param("always_run", True, id="always_run-true"),
+            pytest.param("always_run", "{{ should_always_run }}", id="always_run-template"),
+            pytest.param("always_run", "{{ env == 'production' }}", id="always_run-conditional-template"),
+        ],
+    )
+    def test_field_roundtrip(self, field, value):
+        assert getattr(make_stage(**{field: value}), field) == value
 
 
-class TestStageFixtures:
-    """Tests for Stage.fixtures field."""
+class TestScenarioSimpleFields:
+    """Per-field defaults and round-trips for Scenario's simple fields.
 
-    def test_stage_fixtures_default_empty(self):
-        """Test default fixtures is empty list."""
-        stage = make_stage()
-        assert stage.fixtures == []
+    (auth / stages / substitutions have their own classes below because they
+    coerce and discriminate their inputs rather than storing them verbatim.)"""
 
-    def test_stage_fixtures_single(self):
-        """Test stage with single fixture."""
-        stage = make_stage(fixtures=["auth_token"])
-        assert "auth_token" in stage.fixtures
+    @pytest.mark.parametrize(
+        "attr, default",
+        [
+            ("description", None),
+            ("marks", []),
+        ],
+    )
+    def test_field_default(self, attr, default):
+        assert getattr(Scenario(), attr) == default
 
-    def test_stage_fixtures_multiple(self):
-        """Test stage with multiple fixtures."""
-        stage = make_stage(fixtures=["db_connection", "auth_token", "test_user"])
-        assert len(stage.fixtures) == 3
-
-
-class TestStageAlwaysRun:
-    """Tests for Stage.always_run field."""
-
-    def test_stage_always_run_default_false(self):
-        """Test default always_run is False."""
-        stage = make_stage()
-        assert stage.always_run is False
-
-    def test_stage_always_run_true(self):
-        """Test always_run set to True."""
-        stage = make_stage(name="cleanup", always_run=True)
-        assert stage.always_run is True
-
-    def test_stage_always_run_template(self):
-        """Test always_run with template expression."""
-        stage = make_stage(name="conditional", always_run="{{ should_always_run }}")
-        assert stage.always_run == "{{ should_always_run }}"
-
-    def test_stage_always_run_conditional_template(self):
-        """Test always_run with conditional template."""
-        stage = make_stage(always_run="{{ env == 'production' }}")
-        assert stage.always_run == "{{ env == 'production' }}"
-
-
-class TestScenarioDescription:
-    """Tests for Scenario.description field."""
-
-    def test_scenario_description_default_none(self):
-        """Test default description is None."""
-        scenario = Scenario()
-        assert scenario.description is None
-
-    def test_scenario_description_custom(self):
-        """Test custom description."""
-        scenario = Scenario(
-            description="Test user authentication flow",
-        )
-        assert scenario.description == "Test user authentication flow"
-
-
-class TestScenarioMarks:
-    """Tests for Scenario.marks field."""
-
-    def test_scenario_marks_default_empty(self):
-        """Test default marks is empty list."""
-        scenario = Scenario()
-        assert scenario.marks == []
-
-    def test_scenario_marks_multiple(self):
-        """Test scenario with multiple markers."""
-        scenario = Scenario(marks=["smoke", "critical"])
-        assert "smoke" in scenario.marks
-        assert "critical" in scenario.marks
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            pytest.param("description", "Test user authentication flow", id="description"),
+            pytest.param("marks", ["smoke", "critical"], id="marks-multiple"),
+        ],
+    )
+    def test_field_roundtrip(self, field, value):
+        assert getattr(Scenario(**{field: value}), field) == value
 
 
 class TestScenarioAuth:

--- a/tests/unit/models/test_substitutions_responses.py
+++ b/tests/unit/models/test_substitutions_responses.py
@@ -8,7 +8,6 @@ from pydantic import ValidationError
 from pytest_httpchain.models.entities import (
     FunctionsSubstitution,
     JMESPathSave,
-    Request,
     SaveStep,
     Scenario,
     Stage,
@@ -17,6 +16,7 @@ from pytest_httpchain.models.entities import (
     Verify,
     VerifyStep,
 )
+from tests.unit.models.conftest import make_request, make_stage, stage_dict
 
 
 class TestSubstitutionsListFormat:
@@ -24,20 +24,12 @@ class TestSubstitutionsListFormat:
 
     def test_substitutions_empty_list(self):
         """Test Substitutions with empty list."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            substitutions=[],
-        )
+        stage = make_stage(substitutions=[])
         assert stage.substitutions == []
 
     def test_substitutions_single_vars_item(self):
         """Test Substitutions with single vars item."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            substitutions=[VarsSubstitution(vars={"key1": "value1"})],
-        )
+        stage = make_stage(substitutions=[VarsSubstitution(vars={"key1": "value1"})])
         assert len(stage.substitutions) == 1
         sub0 = stage.substitutions[0]
         assert isinstance(sub0, VarsSubstitution)
@@ -45,9 +37,7 @@ class TestSubstitutionsListFormat:
 
     def test_substitutions_multiple_vars_items(self):
         """Test Substitutions with multiple vars items."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
+        stage = make_stage(
             substitutions=[
                 VarsSubstitution(vars={"key1": "value1"}),
                 VarsSubstitution(vars={"key2": "value2"}),
@@ -62,9 +52,7 @@ class TestSubstitutionsListFormat:
 
     def test_substitutions_mixed_vars_and_functions(self):
         """Test Substitutions with mixed vars and functions."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
+        stage = make_stage(
             substitutions=[
                 VarsSubstitution(vars={"id": 42}),
                 FunctionsSubstitution(functions={"timestamp": UserFunctionName("utils:get_timestamp")}),
@@ -80,24 +68,12 @@ class TestSubstitutionsDictFormat:
 
     def test_substitutions_empty_dict(self):
         """Test Substitutions with empty dict."""
-        stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "substitutions": {},
-            }
-        )
+        stage = Stage.model_validate(stage_dict(substitutions={}))
         assert stage.substitutions == []
 
     def test_substitutions_dict_single_item(self):
         """Test Substitutions with dict containing single item."""
-        stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "substitutions": {"initial": {"vars": {"key1": "value1"}}},
-            }
-        )
+        stage = Stage.model_validate(stage_dict(substitutions={"initial": {"vars": {"key1": "value1"}}}))
         assert len(stage.substitutions) == 1
         sub0 = stage.substitutions[0]
         assert isinstance(sub0, VarsSubstitution)
@@ -106,14 +82,12 @@ class TestSubstitutionsDictFormat:
     def test_substitutions_dict_multiple_items(self):
         """Test Substitutions with dict containing multiple items."""
         stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "substitutions": {
+            stage_dict(
+                substitutions={
                     "first": {"vars": {"key1": "value1"}},
                     "second": {"vars": {"key2": "value2"}},
                 },
-            }
+            )
         )
         assert len(stage.substitutions) == 2
         assert all(isinstance(s, VarsSubstitution) for s in stage.substitutions)
@@ -125,17 +99,15 @@ class TestSubstitutionsDictFormat:
     def test_substitutions_dict_with_list_values(self):
         """Test Substitutions with dict containing list values (flattened)."""
         stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "substitutions": {
+            stage_dict(
+                substitutions={
                     "batch1": [
                         {"vars": {"key1": "value1"}},
                         {"vars": {"key2": "value2"}},
                     ],
                     "batch2": {"vars": {"key3": "value3"}},
                 },
-            }
+            )
         )
         # Expects 3 items total: batch1 list is extended (2 items), batch2 is appended (1 item)
         assert len(stage.substitutions) == 3
@@ -144,14 +116,12 @@ class TestSubstitutionsDictFormat:
     def test_substitutions_dict_mixed_vars_and_functions(self):
         """Test Substitutions dict with mixed vars and functions."""
         stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "substitutions": {
+            stage_dict(
+                substitutions={
                     "initial_data": {"vars": {"id": 42}},
                     "computed_values": {"functions": {"timestamp": "utils:get_timestamp"}},
                 },
-            }
+            )
         )
         assert len(stage.substitutions) == 2
         # Find the VarsSubstitution and FunctionsSubstitution
@@ -166,38 +136,24 @@ class TestResponsesListFormat:
 
     def test_responses_empty_list(self):
         """Test Responses with empty list."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            response=[],
-        )
+        stage = make_stage(response=[])
         assert stage.response == []
 
     def test_responses_single_save_step(self):
         """Test Responses with single save step."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            response=[SaveStep(save=JMESPathSave(jmespath={"result": "data.value"}))],
-        )
+        stage = make_stage(response=[SaveStep(save=JMESPathSave(jmespath={"result": "data.value"}))])
         assert len(stage.response) == 1
         assert isinstance(stage.response[0], SaveStep)
 
     def test_responses_single_verify_step(self):
         """Test Responses with single verify step."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            response=[VerifyStep(verify=Verify(status=HTTPStatus.OK))],
-        )
+        stage = make_stage(response=[VerifyStep(verify=Verify(status=HTTPStatus.OK))])
         assert len(stage.response) == 1
         assert isinstance(stage.response[0], VerifyStep)
 
     def test_responses_multiple_steps(self):
         """Test Responses with multiple steps."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
+        stage = make_stage(
             response=[
                 VerifyStep(verify=Verify(status=HTTPStatus.OK)),
                 SaveStep(save=JMESPathSave(jmespath={"result": "data"})),
@@ -213,55 +169,39 @@ class TestResponsesDictFormat:
 
     def test_responses_empty_dict(self):
         """Test Responses with empty dict."""
-        stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "response": {},
-            }
-        )
+        stage = Stage.model_validate(stage_dict(response={}))
         assert stage.response == []
 
     def test_responses_dict_single_item(self):
         """Test Responses with dict containing single item."""
-        stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "response": {"check_status": {"verify": {"status": 200}}},
-            }
-        )
+        stage = Stage.model_validate(stage_dict(response={"check_status": {"verify": {"status": 200}}}))
         assert len(stage.response) == 1
         assert isinstance(stage.response[0], VerifyStep)
 
     def test_responses_dict_multiple_items(self):
         """Test Responses with dict containing multiple items."""
         stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "response": {
+            stage_dict(
+                response={
                     "verify_success": {"verify": {"status": 200}},
                     "save_result": {"save": {"jmespath": {"data": "response"}}},
                 },
-            }
+            )
         )
         assert len(stage.response) == 2
 
     def test_responses_dict_with_list_values(self):
         """Test Responses with dict containing list values (flattened)."""
         stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "response": {
+            stage_dict(
+                response={
                     "validations": [
                         {"verify": {"status": 200}},
                         {"verify": {"headers": {"Content-Type": "application/json"}}},
                     ],
                     "extraction": {"save": {"jmespath": {"result": "data"}}},
                 },
-            }
+            )
         )
         # Expects 3 items total: validations list extended (2), extraction appended (1)
         assert len(stage.response) == 3
@@ -339,12 +279,7 @@ class TestIntegrationWithScenario:
         """Test Scenario with list-format substitutions."""
         scenario = Scenario(
             substitutions=[VarsSubstitution(vars={"base_url": "https://api.example.com"})],
-            stages=[
-                Stage(
-                    name="test",
-                    request=Request(url="{{ base_url }}/endpoint"),
-                )
-            ],
+            stages=[make_stage(request=make_request(url="{{ base_url }}/endpoint"))],
         )
         assert len(scenario.substitutions) == 1
         assert isinstance(scenario.substitutions[0], VarsSubstitution)
@@ -354,12 +289,7 @@ class TestIntegrationWithScenario:
         scenario = Scenario.model_validate(
             {
                 "substitutions": {"config": {"vars": {"base_url": "https://api.example.com"}}},
-                "stages": [
-                    {
-                        "name": "test",
-                        "request": {"url": "{{ base_url }}/endpoint"},
-                    }
-                ],
+                "stages": [stage_dict(request={"url": "{{ base_url }}/endpoint"})],
             }
         )
         assert len(scenario.substitutions) == 1
@@ -367,23 +297,13 @@ class TestIntegrationWithScenario:
 
     def test_stage_with_list_responses(self):
         """Test Stage with list-format responses."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            response=[VerifyStep(verify=Verify(status=HTTPStatus.OK))],
-        )
+        stage = make_stage(response=[VerifyStep(verify=Verify(status=HTTPStatus.OK))])
         assert len(stage.response) == 1
         assert isinstance(stage.response[0], VerifyStep)
 
     def test_stage_with_dict_responses(self):
         """Test Stage with dict-format responses."""
-        stage = Stage.model_validate(
-            {
-                "name": "test",
-                "request": {"url": "https://example.com"},
-                "response": {"validation": {"verify": {"status": 200}}},
-            }
-        )
+        stage = Stage.model_validate(stage_dict(response={"validation": {"verify": {"status": 200}}}))
         assert len(stage.response) == 1
         assert isinstance(stage.response[0], VerifyStep)
 
@@ -394,42 +314,22 @@ class TestInvalidInputs:
     def test_substitutions_invalid_type(self):
         """Test that invalid types are rejected."""
         with pytest.raises(ValidationError):
-            Stage(
-                name="test",
-                request=Request(url="https://example.com"),
-                substitutions="invalid",
-            )
+            make_stage(substitutions="invalid")
 
     def test_substitutions_invalid_item_structure(self):
         """Test that items with invalid structure are rejected."""
         with pytest.raises(ValidationError, match="does not match any of the expected tags"):
-            Stage.model_validate(
-                {
-                    "name": "test",
-                    "request": {"url": "https://example.com"},
-                    "substitutions": [{"invalid_key": "value"}],
-                }
-            )
+            Stage.model_validate(stage_dict(substitutions=[{"invalid_key": "value"}]))
 
     def test_responses_invalid_type(self):
         """Test that invalid response types are rejected."""
         with pytest.raises(ValidationError):
-            Stage(
-                name="test",
-                request=Request(url="https://example.com"),
-                response="invalid",
-            )
+            make_stage(response="invalid")
 
     def test_responses_invalid_item_structure(self):
         """Test that response items with invalid structure are rejected."""
         with pytest.raises(ValidationError, match="does not match any of the expected tags"):
-            Stage.model_validate(
-                {
-                    "name": "test",
-                    "request": {"url": "https://example.com"},
-                    "response": [{"invalid_key": "value"}],
-                }
-            )
+            Stage.model_validate(stage_dict(response=[{"invalid_key": "value"}]))
 
 
 class TestSubstitutionKeysMustBeIdentifiers:

--- a/tests/unit/models/test_substitutions_responses.py
+++ b/tests/unit/models/test_substitutions_responses.py
@@ -16,7 +16,7 @@ from pytest_httpchain.models.entities import (
     Verify,
     VerifyStep,
 )
-from tests.unit.models.conftest import make_request, make_stage, stage_dict
+from tests.unit.models.conftest import assert_error_types, make_request, make_stage, stage_dict
 
 
 class TestSubstitutionsListFormat:
@@ -318,8 +318,9 @@ class TestInvalidInputs:
 
     def test_substitutions_invalid_item_structure(self):
         """Test that items with invalid structure are rejected."""
-        with pytest.raises(ValidationError, match="does not match any of the expected tags"):
+        with pytest.raises(ValidationError) as exc_info:
             Stage.model_validate(stage_dict(substitutions=[{"invalid_key": "value"}]))
+        assert_error_types(exc_info, "union_tag_invalid")
 
     def test_responses_invalid_type(self):
         """Test that invalid response types are rejected."""
@@ -328,8 +329,9 @@ class TestInvalidInputs:
 
     def test_responses_invalid_item_structure(self):
         """Test that response items with invalid structure are rejected."""
-        with pytest.raises(ValidationError, match="does not match any of the expected tags"):
+        with pytest.raises(ValidationError) as exc_info:
             Stage.model_validate(stage_dict(response=[{"invalid_key": "value"}]))
+        assert_error_types(exc_info, "union_tag_invalid")
 
 
 class TestSubstitutionKeysMustBeIdentifiers:

--- a/tests/unit/models/test_verify.py
+++ b/tests/unit/models/test_verify.py
@@ -8,14 +8,13 @@ from pydantic import ValidationError
 
 from pytest_httpchain.models.entities import (
     HeaderMatcher,
-    Request,
     ResponseBody,
-    Stage,
     UserFunctionKwargs,
     UserFunctionName,
     Verify,
     VerifyStep,
 )
+from tests.unit.models.conftest import make_request, make_stage
 
 
 class TestVerifyStatus:
@@ -331,19 +330,13 @@ class TestVerifyInStage:
 
     def test_stage_with_verify_status(self):
         """Test Stage with status verification."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
-            response=[VerifyStep(verify=Verify(status=HTTPStatus.OK))],
-        )
+        stage = make_stage(response=[VerifyStep(verify=Verify(status=HTTPStatus.OK))])
         assert len(stage.response) == 1
         assert isinstance(stage.response[0], VerifyStep)
 
     def test_stage_with_multiple_verifications(self):
         """Test Stage with multiple verify steps."""
-        stage = Stage(
-            name="test",
-            request=Request(url="https://example.com"),
+        stage = make_stage(
             response=[
                 VerifyStep(verify=Verify(status=HTTPStatus.OK)),
                 VerifyStep(verify=Verify(headers={"Content-Type": "application/json"})),
@@ -355,9 +348,9 @@ class TestVerifyInStage:
 
     def test_stage_with_complex_verification(self):
         """Test Stage with complex verification."""
-        stage = Stage(
+        stage = make_stage(
             name="create-user",
-            request=Request(url="https://example.com/users", method=HTTPMethod.POST),
+            request=make_request(url="https://example.com/users", method=HTTPMethod.POST),
             response=[
                 VerifyStep(
                     verify=Verify(

--- a/tests/unit/templates/test_substitution.py
+++ b/tests/unit/templates/test_substitution.py
@@ -67,19 +67,19 @@ class TestWalk:
         assert result == [1, 2, 3, 4]
 
     def test_dict_creation(self):
-        # Using dict() constructor which is supported by simpleeval
-        result = walk("{{ dict(key='value', number=42) }}", {})
-        assert result == {"key": "value", "number": 42}
+        # Both the dict() constructor and the {} literal are supported.
+        assert walk("{{ dict(key='value', number=42) }}", {}) == {"key": "value", "number": 42}
+        assert walk("{{ {'key': 'value', 'number': 42} }}", {}) == {"key": "value", "number": 42}
+        assert walk("{{ {} }}", {}) == {}
 
     def test_list_comprehension(self):
         result = walk("{{ [x * 2 for x in items] }}", {"items": [1, 2, 3]})
         assert result == [2, 4, 6]
 
     def test_dict_comprehension(self):
-        # Dictionary comprehensions need to be tested differently
-        # simpleeval may not support dict comprehensions directly
-        result = walk("{{ dict([(k, v * 2) for k, v in data.items()]) }}", {"data": {"a": 1, "b": 2}})
-        assert result == {"a": 2, "b": 4}
+        # Dict comprehensions work directly; the dict([(k, v), ...]) form is equivalent.
+        assert walk("{{ {k: v * 2 for k, v in data.items()} }}", {"data": {"a": 1, "b": 2}}) == {"a": 2, "b": 4}
+        assert walk("{{ dict([(k, v * 2) for k, v in data.items()]) }}", {"data": {"a": 1, "b": 2}}) == {"a": 2, "b": 4}
 
     def test_nested_structures(self):
         context = {"users": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}], "index": 0}
@@ -164,9 +164,8 @@ class TestWalk:
         result = walk("{{ get('missing_key', 'default') }}", context)
         assert result == "default"
 
-        # Using get with nested dict access
-        # Note: {} is not a valid literal in simpleeval, use dict() instead
-        result = walk("{{ get('config', dict()).get('missing', 'not found') }}", {})
+        # Using get with nested dict access ({} literal works as the default)
+        result = walk("{{ get('config', {}).get('missing', 'not found') }}", {})
         assert result == "not found"
 
         # Using exists() to safely check before accessing

--- a/tests/unit/test_carrier.py
+++ b/tests/unit/test_carrier.py
@@ -190,6 +190,30 @@ class TestProcessVerifyStepErrors:
         with pytest.raises(VerificationError, match="Expression.*failed"):
             Carrier._process_verify_step(verify, response)
 
+    def test_verify_body_contains_failure(self):
+        response = httpx.Response(200, content=b"hello world")
+        verify = Verify(body=ResponseBody(contains=["goodbye"]))
+        with pytest.raises(VerificationError, match="Body doesn't contain 'goodbye'"):
+            Carrier._process_verify_step(verify, response)
+
+    def test_verify_body_not_contains_failure(self):
+        response = httpx.Response(200, content=b"hello world")
+        verify = Verify(body=ResponseBody(not_contains=["hello"]))
+        with pytest.raises(VerificationError, match="Body contains 'hello' while it shouldn't"):
+            Carrier._process_verify_step(verify, response)
+
+    def test_verify_body_matches_failure(self):
+        response = httpx.Response(200, content=b"hello world")
+        verify = Verify(body=ResponseBody(matches=["z{3}"]))
+        with pytest.raises(VerificationError, match="Body doesn't match 'z"):
+            Carrier._process_verify_step(verify, response)
+
+    def test_verify_body_not_matches_failure(self):
+        response = httpx.Response(200, content=b"hello world")
+        verify = Verify(body=ResponseBody(not_matches=["wor"]))
+        with pytest.raises(VerificationError, match="Body matches 'wor' while it shouldn't"):
+            Carrier._process_verify_step(verify, response)
+
 
 def _make_stage(**kwargs) -> Stage:
     """Minimal valid stage pointing at a URL that is never actually requested in

--- a/tests/unit/test_carrier.py
+++ b/tests/unit/test_carrier.py
@@ -24,6 +24,8 @@ from pytest_httpchain.models import (
     JMESPathSave,
     ParallelRepeatConfig,
     Request,
+    Scenario,
+    SSLConfig,
     Stage,
     Verify,
 )
@@ -243,6 +245,50 @@ def _make_carrier_subclass(**attrs) -> type[Carrier]:
     }
     defaults.update(attrs)
     return type("UnitCarrier", (Carrier,), defaults)
+
+
+class TestSSLClientWiring:
+    """SSLConfig -> httpx.Client kwargs, the ssl branches of _ensure_initialized.
+
+    No real TLS handshake or cert files are needed: httpx.Client is captured so
+    the test asserts exactly what verify/cert the engine hands it. These branches
+    have no runtime coverage otherwise (the mock server used by the integration
+    suite is plain HTTP)."""
+
+    def _client_kwargs_for(self, monkeypatch, ssl: SSLConfig) -> dict:
+        captured: dict = {}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("pytest_httpchain.carrier.httpx.Client", FakeClient)
+        cls = _make_carrier_subclass(
+            _initialized=False,
+            _context_resolved_at_collection=True,
+            scenario=Scenario(ssl=ssl),
+        )
+        cls._ensure_initialized()
+        return captured
+
+    def test_verify_false_passed_through(self, monkeypatch):
+        assert self._client_kwargs_for(monkeypatch, SSLConfig(verify=False))["verify"] is False
+
+    def test_verify_path_resolved_to_str(self, monkeypatch, tmp_path):
+        ca = tmp_path / "ca-bundle.pem"
+        ca.write_text("dummy")
+        assert self._client_kwargs_for(monkeypatch, SSLConfig(verify=ca))["verify"] == str(ca)
+
+    def test_cert_pair_resolved_and_normalized(self, monkeypatch, tmp_path):
+        crt, key = tmp_path / "client.crt", tmp_path / "client.key"
+        crt.write_text("c")
+        key.write_text("k")
+        assert self._client_kwargs_for(monkeypatch, SSLConfig(cert=(crt, key)))["cert"] == (str(crt), str(key))
+
+    def test_single_cert_resolved_and_normalized(self, monkeypatch, tmp_path):
+        crt = tmp_path / "client.pem"
+        crt.write_text("c")
+        assert self._client_kwargs_for(monkeypatch, SSLConfig(cert=crt))["cert"] == str(crt)
 
 
 class TestRateLimiting:

--- a/tests/unit/test_har_writer.py
+++ b/tests/unit/test_har_writer.py
@@ -1,9 +1,10 @@
+import base64
 import datetime
 import json
 
 import httpx
 
-from pytest_httpchain.har_writer import write_har_file
+from pytest_httpchain.har_writer import request_response_to_har_entry, write_har_file
 
 
 def _make_pair(elapsed_ms: float | None = 123.5) -> tuple[httpx.Request, httpx.Response]:
@@ -153,6 +154,75 @@ class TestPerExchangeStartTimes:
         path = write_har_file(tmp_path, "t", [(req, resp, None)])
         entries = json.loads(path.read_text())["log"]["entries"]
         datetime.fromisoformat(entries[0]["startedDateTime"])
+
+
+class TestSerializationFamilies:
+    """Direct coverage of request_response_to_har_entry's body/header branches.
+
+    Each family below hits a distinct serializer that the file-level tests
+    (JSON body, happy path) never exercise.
+    """
+
+    def test_request_cookie_header_parsed(self):
+        req = httpx.Request("GET", "https://x.com/p", headers={"cookie": "s=abc; t=def"})
+        entry = request_response_to_har_entry(req, httpx.Response(200, request=req))
+        assert entry["request"]["cookies"] == [
+            {"name": "s", "value": "abc"},
+            {"name": "t", "value": "def"},
+        ]
+
+    def test_response_set_cookie_serialized(self):
+        req = httpx.Request("GET", "https://x.com/p")
+        resp = httpx.Response(200, headers={"set-cookie": "session=xyz; Path=/"}, request=req)
+        entry = request_response_to_har_entry(req, resp)
+        assert entry["response"]["cookies"] == [{"name": "session", "value": "xyz"}]
+
+    def test_query_string_extracted(self):
+        req = httpx.Request("GET", "https://x.com/p?a=1&b=2&a=3")
+        entry = request_response_to_har_entry(req, httpx.Response(200, request=req))
+        # Repeated keys are preserved as separate entries, per HAR.
+        assert entry["request"]["queryString"] == [
+            {"name": "a", "value": "1"},
+            {"name": "a", "value": "3"},
+            {"name": "b", "value": "2"},
+        ]
+
+    def test_form_urlencoded_body_params(self):
+        req = httpx.Request("POST", "https://x.com", data={"k1": "v1", "k2": "v2"})
+        entry = request_response_to_har_entry(req, httpx.Response(200, request=req))
+        post = entry["request"]["postData"]
+        assert post["mimeType"] == "application/x-www-form-urlencoded"
+        assert {"name": "k1", "value": "v1"} in post["params"]
+        assert {"name": "k2", "value": "v2"} in post["params"]
+
+    def test_binary_request_body_base64_encoded(self):
+        raw = b"\xff\xfe\x00"
+        req = httpx.Request("POST", "https://x.com", content=raw, headers={"content-type": "application/octet-stream"})
+        entry = request_response_to_har_entry(req, httpx.Response(200, request=req))
+        post = entry["request"]["postData"]
+        assert post["encoding"] == "base64"
+        assert base64.b64decode(post["text"]) == raw
+
+    def test_binary_response_body_base64_encoded(self):
+        raw = b"\xff\xfe"
+        req = httpx.Request("GET", "https://x.com")
+        resp = httpx.Response(200, content=raw, headers={"content-type": "application/octet-stream"}, request=req)
+        content = request_response_to_har_entry(req, resp)["response"]["content"]
+        assert content["encoding"] == "base64"
+        assert content["size"] == len(raw)
+        assert base64.b64decode(content["text"]) == raw
+
+    def test_empty_response_body_has_no_text(self):
+        req = httpx.Request("GET", "https://x.com")
+        resp = httpx.Response(204, request=req)
+        content = request_response_to_har_entry(req, resp)["response"]["content"]
+        assert content["size"] == 0
+        assert "text" not in content
+
+    def test_empty_request_body_has_no_post_data(self):
+        req = httpx.Request("GET", "https://x.com")
+        entry = request_response_to_har_entry(req, httpx.Response(200, request=req))
+        assert "postData" not in entry["request"]
 
 
 class TestFilenameCollisions:

--- a/tests/unit/userfunc/test_name_pattern.py
+++ b/tests/unit/userfunc/test_name_pattern.py
@@ -41,7 +41,8 @@ class TestValidModulePatterns:
         assert callable(func)
 
     def test_underscore_in_module(self):
-        func = import_function("collections.abc:Callable")
+        # wsgiref.simple_server has an underscore in a module segment.
+        func = import_function("wsgiref.simple_server:demo_app")
         assert func is not None
 
     def test_numeric_in_module(self):


### PR DESCRIPTION
Implements the actionable findings from a multi-agent audit of the test suite (unit + integration), focused on coverage, readability, and ease of maintenance. Six focused commits, each independently green.

**Status:** 1105 passed, 1 skipped · **93.74% coverage** (was 92.03%) · all four lint gates pass (`ruff check`, `ruff format`, `ty`, `lint-imports`) · full suite ~40s faster.

## Headline: reported coverage was misleading by ~20 points

`pytest --cov` counts every model field / class-body line as missed because the plugin imports via its `pytest11` entry point before pytest-cov starts recording. CI already avoids this with `coverage run -m pytest` (real total **~93%**); only the `CLAUDE.md` dev command still documented the misleading `--cov` form — now fixed.

## Coverage

- **`har_writer.py` 77% → 97%** — new `TestSerializationFamilies` covers the six untested serializers: request/response cookies, `Cookie`-header parsing, query strings, form params, base64 request/response bodies, empty bodies.
- **SSL client wiring** (`carrier.py` ssl branches) — `TestSSLClientWiring` captures the `httpx.Client` kwargs `_ensure_initialized` builds (verify=False pass-through, CA-bundle Path→str, single/pair cert resolve + normalize). No real TLS needed.
- **Verify user-function failure paths** — three integration scenarios exercise a verify function that returns False, returns a non-bool, and raises (wrapped as a clean stage failure).
- **Text-matcher failure raises** (`not_contains` / `matches` / `not_matches`) — previously only the `contains` failure ran.
- **Filled the 0-byte `test_entities.py`** with a truth table for `parametrize_values_contain_template` (the combinations-with-template branch had no test).
- CI now **enforces** coverage via `fail_under = 88` (real ~93%, margin for platform branch differences).

## Readability & maintainability

- **New `tests/unit/models/conftest.py`** (`make_request` / `make_stage` / `stage_dict`) — migrated ~45 incidental Stage/Request scaffolding sites; each builds the identical object/dict, sites where the construction is the subject-under-test left explicit.
- **Stable pydantic error codes** — replaced 14 brittle `match="Extra inputs are not permitted"` / `"does not match any of the expected tags"` / `"at least 1"` assertions with the version-stable `type` codes (`extra_forbidden`, `union_tag_invalid`, `too_short`, `too_long`); the models' own validator messages are kept as message matches.
- **Collapsed `test_stage_scenario.py`** per-field tests (7 namespace-only classes) into parametrized default/round-trip tables — same 36 tests, stronger equality assertions.
- Fixed three factually-false comments in `test_substitution.py` (`{}` literals / dict comprehensions do work); fixed two mis-named tests (`test_underscore_in_module` used a module with no underscore; `test_verify_non_template_string_treated_as_path` passed a Path, not a string); removed leftover debug prints; deleted dead `scoping.stage_defined_names`.
- Added `.editorconfig` codifying the repo's uniform 4-space indent.

## Performance / flakiness / CI

- **Timeout scenario** now uses a millisecond `/delay_ms` route instead of `/delay/5`, so the single-threaded mock server no longer sleeps whole seconds into teardown (~5s → ~1.3s).
- **`slow` marker** on the subprocess (xdist/ordering) and 10s rate-limiter-leak tests → `pytest -m "not slow"` for fast local loops.
- **Warnings-as-errors gate** (`filterwarnings = ["error", ...]`) so dependency deprecations fail loudly; the plugin's intentional `ScenarioValidationWarning` is explicitly excluded (verified it does not leak into pytester inner runs).
- `log_cli` defaults to **false** (was streaming live INFO for every passing test, ~10-27x output inflation); opt back in per-run.
- Gated the connection-refused test's `timed out` acceptance to Windows only; skip (not flake) `test_invalid_hostname` on NXDOMAIN-wildcarding resolvers; added `timeout-minutes` to all CI jobs.

## Notes

- The audit ran 10 specialized auditors with an adversarial verification pass (96 raw → 85 confirmed, 6 refuted); the refuted candidates (e.g. "port allocation assumes serial runs" — the repo deliberately tests xdist) were not acted on.
- A prettier/node CI gate for JSON array wrapping was deliberately **not** added — disproportionate for a Python-only project; `.editorconfig` gives editors the indent rule at zero CI cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxKxbPkmpF8RAXgUeWh9q5)_