### PR TITLE
Abort scenario chains from final pytest outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Chain aborts now follow pytest's final item outcome rather than trying to predict it inside the stage body. Fixture setup/teardown errors and strict XPASS failures now stop later stages, false string `xfail` conditions no longer let genuine failures through, and skips plus genuine expected failures still continue as documented.
+
 ## [0.14.3] - 2026-08-11
 
 ### Fixed

--- a/src/pytest_httpchain/carrier.py
+++ b/src/pytest_httpchain/carrier.py
@@ -58,7 +58,7 @@ from pytest_httpchain.scoping import (
     with_stage_substitutions,
 )
 from pytest_httpchain.templates import TemplatesError, walk
-from pytest_httpchain.utils import make_marker, process_substitutions
+from pytest_httpchain.utils import process_substitutions
 from pytest_httpchain.warnings import ScenarioValidationWarning
 
 logger = logging.getLogger(__name__)
@@ -85,22 +85,6 @@ def _response_meta(response: httpx.Response) -> SimpleNamespace:
         headers=response.headers,
         elapsed_ms=elapsed_ms,
     )
-
-
-def _is_active_xfail(mark: pytest.MarkDecorator) -> bool:
-    """True when the mark is an xfail that will actually apply to the item.
-
-    Mirrors pytest's ``evaluate_xfail_marks``: no conditions means unconditional,
-    otherwise any truthy one activates it. An inactive xfail means pytest counts
-    the failure as genuine, so the abort machinery must too; string conditions
-    (which pytest evaluates itself) are conservatively treated as active.
-    """
-    if mark.name != "xfail":
-        return False
-    conditions = (mark.kwargs["condition"],) if "condition" in mark.kwargs else mark.args
-    if not conditions:
-        return True
-    return any(isinstance(condition, str) or bool(condition) for condition in conditions)
 
 
 def _error_request(e: Exception) -> httpx.Request | None:
@@ -218,8 +202,10 @@ class Carrier:
         Gates on the abort/``always_run`` flow, layers the stage context, runs
         the iteration matrix, and on full success commits the collected saves as
         a new global-context layer. A failure is reported via ``pytest.fail``
-        and aborts the chain unless the stage is marked xfail; a failing stage
-        commits no saves, so the context never carries a timing-dependent subset.
+        and commits no saves, so the context never carries a timing-dependent
+        subset. The report hook owns chain-abort classification because only
+        pytest's final report knows whether xfail/strict and setup/teardown made
+        the item a genuine failure.
         """
         # Reset before anything can fail or skip: a stage that never records an
         # exchange must report nothing, not the previous stage's.
@@ -283,13 +269,6 @@ class Carrier:
                 raise exc
 
         except _STAGE_FAILURE_EXCEPTIONS as e:
-            # Structural detection, so `skip(reason="...xfail...")` or a custom
-            # `my_xfail` marker is not misclassified. An xfail stage's failure is
-            # expected and must not abort the chain.
-            is_xfail = any(_is_active_xfail(make_marker(mark)) for mark in stage.marks)
-            if not is_xfail:
-                logger.error(str(e))
-                cls.aborted = True
             failure_reason = str(e)
 
         # Deliberately outside the handler: raising there would set

--- a/src/pytest_httpchain/plugin.py
+++ b/src/pytest_httpchain/plugin.py
@@ -340,21 +340,24 @@ def pytest_collect_file(file_path: Path, parent: pytest.Collector) -> pytest.Col
     return None
 
 
-@pytest.hookimpl(wrapper=True)
+@pytest.hookimpl(wrapper=True, tryfirst=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> Any:
-    # The yielded report is augmented in place and returned so it propagates to
-    # outer wrappers.
+    # tryfirst makes this the outermost wrapper: its post-yield half sees the
+    # final outcome after pytest has applied skip/xfail/strict semantics.
     report: pytest.TestReport = yield
 
+    item_cls = getattr(item, "cls", None)
+    carrier_class = item_cls if isinstance(item_cls, type) and issubclass(item_cls, Carrier) else None
+
     if call.when == "call":
-        if hasattr(item, "instance") and isinstance(item.instance, Carrier):
-            carrier = item.instance
+        if carrier_class is not None:
+            carrier = carrier_class
 
             # An initialization failure breaks the whole scenario and must stay
             # red, so undo the xfail conversion pytest's skipping plugin already
             # applied (this wrapper is outermost, so every consumer sees the
             # flip). `wasxfail` holds a reason string: presence is the signal.
-            if type(carrier)._init_failed is not None and report.skipped and hasattr(report, "wasxfail"):
+            if carrier._init_failed is not None and report.skipped and hasattr(report, "wasxfail"):
                 report.outcome = "failed"
                 del report.wasxfail
 
@@ -386,7 +389,7 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> 
                 if exchange is None:
                     continue
                 try:
-                    body = formatter(exchange)  # ty: ignore[invalid-argument-type]
+                    body = formatter(exchange)
                 except Exception as e:
                     body = f"<Error formatting {what}: {e}>"
                 report.sections.append((f"{title}{suffix}", body))
@@ -402,5 +405,12 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> 
                     report.sections.append(("HAR File", str(har_path)))
                 except Exception as e:
                     logger.warning(f"Failed to write HAR file for {item.nodeid}: {e}")
+
+    # The report, not the stage body, is the source of truth. Fixture setup and
+    # teardown can fail without execute_stage running, and strict XPASS plus
+    # string xfail conditions are classified only by pytest. Expected xfails and
+    # ordinary skips are `skipped`, so they deliberately leave the chain healthy.
+    if carrier_class is not None and report.failed:
+        carrier_class.aborted = True
 
     return report

--- a/tests/integration/examples/conftest.py
+++ b/tests/integration/examples/conftest.py
@@ -348,6 +348,19 @@ def request_id():
     return _make_id
 
 
+@pytest.fixture
+def fixture_setup_error():
+    """Fail before a generated stage method can enter Carrier.execute_stage."""
+    raise RuntimeError("fixture setup failed")
+
+
+@pytest.fixture
+def fixture_teardown_error():
+    """Fail after the stage body passed, before pytest advances the chain."""
+    yield
+    raise RuntimeError("fixture teardown failed")
+
+
 # ============ Error Testing Endpoints ============
 
 

--- a/tests/integration/examples/errors/test_fixture_setup_abort.http.json
+++ b/tests/integration/examples/errors/test_fixture_setup_abort.http.json
@@ -1,0 +1,16 @@
+{
+    "stages": [
+        {
+            "name": "setup_error",
+            "fixtures": ["fixture_setup_error"],
+            "request": {"url": "https://x.test/"},
+            "response": [{"verify": {"status": 200}}]
+        },
+        {
+            "name": "must_not_run",
+            "fixtures": ["server"],
+            "request": {"url": "{{ server }}/ok"},
+            "response": [{"verify": {"status": 200}}]
+        }
+    ]
+}

--- a/tests/integration/examples/errors/test_fixture_teardown_abort.http.json
+++ b/tests/integration/examples/errors/test_fixture_teardown_abort.http.json
@@ -1,0 +1,16 @@
+{
+    "stages": [
+        {
+            "name": "teardown_error",
+            "fixtures": ["server", "fixture_teardown_error"],
+            "request": {"url": "{{ server }}/ok"},
+            "response": [{"verify": {"status": 200}}]
+        },
+        {
+            "name": "must_not_run",
+            "fixtures": ["server"],
+            "request": {"url": "{{ server }}/ok"},
+            "response": [{"verify": {"status": 200}}]
+        }
+    ]
+}

--- a/tests/integration/examples/marks/test_strict_xpass_abort.http.json
+++ b/tests/integration/examples/marks/test_strict_xpass_abort.http.json
@@ -1,0 +1,17 @@
+{
+    "stages": [
+        {
+            "name": "unexpected_pass",
+            "marks": ["xfail(strict=True, reason=\"expected failure\")"],
+            "fixtures": ["server"],
+            "request": {"url": "{{ server }}/ok"},
+            "response": [{"verify": {"status": 200}}]
+        },
+        {
+            "name": "must_not_run",
+            "fixtures": ["server"],
+            "request": {"url": "{{ server }}/ok"},
+            "response": [{"verify": {"status": 200}}]
+        }
+    ]
+}

--- a/tests/integration/test_chain_abort.py
+++ b/tests/integration/test_chain_abort.py
@@ -1,0 +1,13 @@
+def test_fixture_setup_error_aborts_chain(run_scenario):
+    result = run_scenario("errors/test_fixture_setup_abort.http.json")
+    result.assert_outcomes(errors=1, failed=0, passed=0, skipped=1)
+
+
+def test_fixture_teardown_error_aborts_chain(run_scenario):
+    result = run_scenario("errors/test_fixture_teardown_abort.http.json")
+    result.assert_outcomes(errors=1, failed=0, passed=1, skipped=1)
+
+
+def test_strict_xpass_aborts_chain(run_scenario):
+    result = run_scenario("marks/test_strict_xpass_abort.http.json")
+    result.assert_outcomes(errors=0, failed=1, passed=0, skipped=1)

--- a/tests/integration/test_marks.py
+++ b/tests/integration/test_marks.py
@@ -79,8 +79,10 @@ def _rewrite_marks(pytester, marks):
     [
         ['xfail(False, reason="disabled condition")'],
         ['xfail(condition=False, reason="disabled condition")'],
+        ['xfail("False", reason="disabled string condition")'],
+        ['xfail(condition="False", reason="disabled string condition")'],
     ],
-    ids=["positional", "kwarg"],
+    ids=["positional-bool", "kwarg-bool", "positional-string", "kwarg-string"],
 )
 def test_inactive_xfail_aborts_chain(pytester, marks):
     """An INACTIVE xfail — falsy condition, in either the positional or the
@@ -101,5 +103,15 @@ def test_multi_condition_active_xfail_does_not_abort(pytester):
     pytester.copy_example("conftest.py")
     pytester.copy_example("marks/test_xfail_false_condition.http.json")
     _rewrite_marks(pytester, ['xfail(True, False, reason="one truthy condition")'])
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(errors=0, failed=0, passed=1, xfailed=1)
+
+
+def test_active_string_xfail_does_not_abort(pytester):
+    """Let pytest evaluate string conditions; a true one is still expected and
+    must preserve the documented continue-after-xfail behavior."""
+    pytester.copy_example("conftest.py")
+    pytester.copy_example("marks/test_xfail_false_condition.http.json")
+    _rewrite_marks(pytester, ['xfail("True", reason="active string condition")'])
     result = pytester.runpytest("-s")
     result.assert_outcomes(errors=0, failed=0, passed=1, xfailed=1)


### PR DESCRIPTION
## Summary

- make final pytest reports authoritative for chain aborts
- cover setup and teardown failures plus strict XPASS
- let pytest evaluate boolean and string xfail conditions

## Testing

- focused integration suite: 18 passed
- full suite: 1164 passed, 2 deselected
- Ruff, formatting, ty, and import-linter checks passed