### PR TITLE
Preserve scoped response cookies in HAR exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- HAR export preserves same-name response cookies with different domain/path scopes instead of raising `httpx.CookieConflict` and silently dropping the test's HAR file.
+
 ## [0.14.3] - 2026-08-11
 
 ### Fixed

--- a/src/pytest_httpchain/har_writer.py
+++ b/src/pytest_httpchain/har_writer.py
@@ -25,8 +25,29 @@ def _get_version() -> str:
         return "unknown"
 
 
-def _format_cookies(cookies: httpx.Cookies) -> list[dict[str, str]]:
-    return [{"name": name, "value": value} for name, value in cookies.items()]
+def _format_cookies(cookies: httpx.Cookies) -> list[dict[str, Any]]:
+    """Serialize jar entries without collapsing cookies by name.
+
+    ``httpx.Cookies.items()`` performs a name-only lookup and raises
+    ``CookieConflict`` when the same name exists at different paths/domains — a
+    valid and common response. Iterating the jar preserves each scoped cookie.
+    """
+    result: list[dict[str, Any]] = []
+    for cookie in cookies.jar:
+        item: dict[str, Any] = {
+            "name": cookie.name,
+            "value": cookie.value or "",
+            "secure": bool(cookie.secure),
+            "httpOnly": cookie.has_nonstandard_attr("HttpOnly"),
+        }
+        if cookie.path:
+            item["path"] = cookie.path
+        if cookie.domain:
+            item["domain"] = cookie.domain
+        if cookie.expires is not None:
+            item["expires"] = datetime.fromtimestamp(cookie.expires, UTC).isoformat()
+        result.append(item)
+    return result
 
 
 def _parse_cookie_header(cookie_header: str) -> list[dict[str, str]]:

--- a/tests/integration/examples/conftest.py
+++ b/tests/integration/examples/conftest.py
@@ -207,6 +207,17 @@ def get_headers():
     return resp
 
 
+@app.get("/scoped-cookies")
+def scoped_cookies():
+    """Return two valid same-name cookies with different path scopes."""
+    from flask import make_response
+
+    resp = make_response({})
+    resp.set_cookie("session", "root", path="/")
+    resp.set_cookie("session", "admin", path="/admin")
+    return resp
+
+
 @app.get("/schema-test")
 def schema_test():
     """Return data for JSON schema validation"""

--- a/tests/integration/test_har_output.py
+++ b/tests/integration/test_har_output.py
@@ -29,6 +29,38 @@ def test_har_file_written(pytester):
     assert har["log"]["entries"], "HAR log must contain at least one entry"
 
 
+def test_har_preserves_same_name_cookies_with_different_paths(pytester):
+    """A valid response may scope the same cookie name to several paths;
+    exporting it must not raise httpx.CookieConflict and drop the HAR file."""
+    har_dir = pytester.path / "har_out"
+    pytester.copy_example("conftest.py")
+    (pytester.path / "test_scoped_cookies.http.json").write_text(
+        json.dumps(
+            {
+                "stages": [
+                    {
+                        "name": "scoped_cookies",
+                        "fixtures": ["server"],
+                        "request": {"url": "{{ server }}/scoped-cookies"},
+                        "response": [{"verify": {"status": 200}}],
+                    }
+                ]
+            }
+        )
+    )
+
+    result = pytester.runpytest("-s", "--httpchain-output-dir", str(har_dir))
+
+    result.assert_outcomes(errors=0, failed=0, passed=1)
+    har_files = list(har_dir.glob("*.har"))
+    assert len(har_files) == 1
+    cookies = json.loads(har_files[0].read_text(encoding="utf-8"))["log"]["entries"][0]["response"]["cookies"]
+    assert {(cookie["name"], cookie["value"], cookie["path"]) for cookie in cookies} == {
+        ("session", "root", "/"),
+        ("session", "admin", "/admin"),
+    }
+
+
 def test_parallel_stage_har_contains_every_iteration(pytester):
     """A parallel stage's HAR must hold one entry per iteration, not a single
     arbitrary iteration presented as the stage's only exchange. The report

--- a/tests/unit/test_har_writer.py
+++ b/tests/unit/test_har_writer.py
@@ -175,7 +175,36 @@ class TestSerializationFamilies:
         req = httpx.Request("GET", "https://x.com/p")
         resp = httpx.Response(200, headers={"set-cookie": "session=xyz; Path=/"}, request=req)
         entry = request_response_to_har_entry(req, resp)
-        assert entry["response"]["cookies"] == [{"name": "session", "value": "xyz"}]
+        assert entry["response"]["cookies"] == [
+            {
+                "name": "session",
+                "value": "xyz",
+                "secure": False,
+                "httpOnly": False,
+                "path": "/",
+                "domain": "x.com",
+            }
+        ]
+
+    def test_same_name_response_cookies_keep_distinct_scopes(self):
+        req = httpx.Request("GET", "https://x.com/")
+        resp = httpx.Response(
+            200,
+            headers=[
+                ("set-cookie", "session=root; Path=/; Secure; HttpOnly"),
+                ("set-cookie", "session=admin; Path=/admin"),
+            ],
+            request=req,
+        )
+
+        cookies = request_response_to_har_entry(req, resp)["response"]["cookies"]
+
+        assert [(cookie["name"], cookie["value"], cookie["path"]) for cookie in cookies] == [
+            ("session", "root", "/"),
+            ("session", "admin", "/admin"),
+        ]
+        assert cookies[0]["secure"] is True
+        assert cookies[0]["httpOnly"] is True
 
     def test_query_string_extracted(self):
         req = httpx.Request("GET", "https://x.com/p?a=1&b=2&a=3")


### PR DESCRIPTION
## Summary

- serialize response cookies directly from the cookie jar
- preserve same-name cookies with different paths or domains
- include cookie scope and security metadata in HAR output

## Testing

- focused unit suite: 23 passed
- focused HAR integration suite: 9 passed
- full suite: 1160 passed, 2 deselected
- Ruff, formatting, ty, and import-linter checks passed