### PR TITLE
Serialize repeated form fields correctly in HAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Repeated URL-encoded form fields are emitted as separate scalar HAR `postData.params` entries, preserving their wire order and producing valid HAR instead of an array-valued parameter.
+
 ## [0.14.3] - 2026-08-11
 
 ### Fixed

--- a/src/pytest_httpchain/har_writer.py
+++ b/src/pytest_httpchain/har_writer.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from importlib.metadata import version
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlparse
 
 import httpx
 
@@ -71,8 +71,9 @@ def _format_post_data(request: httpx.Request) -> dict[str, Any] | None:
     }
 
     if "application/x-www-form-urlencoded" in content_type:
-        params = parse_qs(text, keep_blank_values=True)
-        post_data["params"] = [{"name": k, "value": v[0] if len(v) == 1 else v} for k, v in params.items()]
+        # HAR params are repeated scalar name/value records, not one record with
+        # an array value. parse_qsl also preserves the body's original ordering.
+        post_data["params"] = [{"name": name, "value": value} for name, value in parse_qsl(text, keep_blank_values=True)]
 
     return post_data
 

--- a/tests/integration/test_har_output.py
+++ b/tests/integration/test_har_output.py
@@ -29,6 +29,41 @@ def test_har_file_written(pytester):
     assert har["log"]["entries"], "HAR log must contain at least one entry"
 
 
+def test_har_form_repeats_are_separate_scalar_params(pytester):
+    har_dir = pytester.path / "har_out"
+    pytester.copy_example("conftest.py")
+    (pytester.path / "test_repeated_form.http.json").write_text(
+        json.dumps(
+            {
+                "stages": [
+                    {
+                        "name": "repeated_form",
+                        "fixtures": ["server"],
+                        "request": {
+                            "url": "{{ server }}/echo/form",
+                            "method": "POST",
+                            "body": {"form": {"tag": ["one", "two"], "empty": ""}},
+                        },
+                        "response": [{"verify": {"status": 200}}],
+                    }
+                ]
+            }
+        )
+    )
+
+    result = pytester.runpytest("-s", "--httpchain-output-dir", str(har_dir))
+
+    result.assert_outcomes(errors=0, failed=0, passed=1)
+    har_files = list(har_dir.glob("*.har"))
+    assert len(har_files) == 1
+    params = json.loads(har_files[0].read_text(encoding="utf-8"))["log"]["entries"][0]["request"]["postData"]["params"]
+    assert params == [
+        {"name": "tag", "value": "one"},
+        {"name": "tag", "value": "two"},
+        {"name": "empty", "value": ""},
+    ]
+
+
 def test_parallel_stage_har_contains_every_iteration(pytester):
     """A parallel stage's HAR must hold one entry per iteration, not a single
     arbitrary iteration presented as the stage's only exchange. The report

--- a/tests/unit/test_har_writer.py
+++ b/tests/unit/test_har_writer.py
@@ -195,6 +195,18 @@ class TestSerializationFamilies:
         assert {"name": "k1", "value": "v1"} in post["params"]
         assert {"name": "k2", "value": "v2"} in post["params"]
 
+    def test_repeated_form_values_are_separate_scalar_params(self):
+        req = httpx.Request("POST", "https://x.com", content=b"tag=one&tag=two&empty=", headers={"content-type": "application/x-www-form-urlencoded"})
+
+        params = request_response_to_har_entry(req, httpx.Response(200, request=req))["request"]["postData"]["params"]
+
+        assert params == [
+            {"name": "tag", "value": "one"},
+            {"name": "tag", "value": "two"},
+            {"name": "empty", "value": ""},
+        ]
+        assert all(isinstance(param["value"], str) for param in params)
+
     def test_binary_request_body_base64_encoded(self):
         raw = b"\xff\xfe\x00"
         req = httpx.Request("POST", "https://x.com", content=raw, headers={"content-type": "application/octet-stream"})


### PR DESCRIPTION
## Summary

- parse form bodies as ordered key-value pairs
- emit one scalar HAR parameter per repeated field
- retain blank form values and field ordering

## Testing

- focused unit suite: 23 passed
- focused HAR integration suite: 9 passed
- full suite: 1160 passed, 2 deselected
- Ruff, formatting, ty, and import-linter checks passed